### PR TITLE
Simplify memory definition

### DIFF
--- a/UCL-cscluster/cscluster.config
+++ b/UCL-cscluster/cscluster.config
@@ -13,66 +13,44 @@ process {
     errorStrategy = 'terminate'
     maxRetries = 0
 
+    //ADD DEFAULT RESOURCE VALUES FOR UNLABELLED PROCESSES
+    cpus   = 1
+    time   = 6.h
+    memory = 6.GB
+
+    //ADD MEMORY TO CLUSTEROPTIONS 
+    clusterOptions = { "-S /bin/bash -l tmem=${task.memory.mega}M,h_vmem=${task.memory.mega}M" }
+
     withLabel:process_single {
         cpus   = 1
         time   = 1.h
-
-        def sge_mem_gb = ("6.GB" as nextflow.util.MemoryUnit)
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 6.GB
     }
     withLabel:process_low {
         cpus   = 2
         time   = 2.h
-
-        def sge_mem_gb = ("6.GB" as nextflow.util.MemoryUnit) 
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 6.GB
     }
     withLabel:process_medium {
         cpus   = 4
         time   = 4.h
-
-        def sge_mem_gb = ("10.GB" as nextflow.util.MemoryUnit)
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 10.GB
     }
     withLabel:process_high {
         cpus   = 8
         time   = 8.h
-
-        def sge_mem_gb = ("16.GB" as nextflow.util.MemoryUnit)
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 16.GB
     }
     withLabel:process_long {
         cpus   = 1
         time   = 24.h
-
-        def sge_mem_gb = ("2.GB" as nextflow.util.MemoryUnit)
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 2.GB
     }
     withLabel:process_high_memory {
 
         cpus   = 1
         time   = 1.h
-
-        def sge_mem_gb = ("64.GB" as nextflow.util.MemoryUnit)
-        def sge_mem_mb = ("${sge_mem_gb}".toString().split(" ")[0].toInteger() * 1024)
-        memory = "${sge_mem_gb}"
-
-        clusterOptions = "-S /bin/bash -l tmem=${sge_mem_mb}M,h_vmem=${sge_mem_mb}M"
+        memory = 64.GB
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'


### PR DESCRIPTION
- Add default resource values for unlabelled processes
- Use task.memory.mega property to make the memory allocation more readable